### PR TITLE
1.10.0 Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ You may use environment variables to configure your config files. The variables 
 If you run into the error message ```Error running "login"``` this is a sign that your iptables uses an older API call. Enable the environment variable ```LEGACY_IPTABLES=true``` to
 force the system to use the legacy IPTables.
 
+#### [Errno 1] Operation not permitted
+If this error is thrown, that means that the OS is not allowing commands to execute in python. Currently the work around that has worked for me is setting the flag ```--privileged```. In the future, I'll take a closer look at which permissions are causing the problems.
+
 ### 1. Authorization
 You will need to create a config file to auto-login to Windscribe.
 You can either set some environment variables or configure a config file. The login information will be identical to the username and password you use to login to your windscribe profile. Below goes over both approaches.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM ubuntu:20.04
 
 LABEL maintainer="kabe0"
 
@@ -15,7 +15,7 @@ ENV DEL_INT=tun0
 ENV VPN_ENABLE=True
 ENV LEGACY_IPTABLES=False
 ENV VPN_AUTH="/config/auth.conf"
-ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1WEB_PORT
 ENV WEBPROXY_ENABLED=false
 ENV WEBPROXY_PORT=8888
 ENV WEBPROXY_USERNAME=""
@@ -27,7 +27,9 @@ RUN \
  apt-get install -y  && \
  apt-get install -y software-properties-common dirmngr apt-transport-https && \
  apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-key FDC247B7 && \
- echo 'deb https://repo.windscribe.com/debian buster main' | tee /etc/apt/sources.list.d/windscribe-repo.list && \
+ add-apt-repository ppa:deluge-team/stable && \
+ add-apt-repository ppa:libtorrent.org/1.2-daily && \
+ echo 'deb https://repo.windscribe.com/debian bionic main' | tee /etc/apt/sources.list.d/windscribe-repo.list && \
  apt-get update && \
  apt-get install -y \
 	python3 python3-pip windscribe-cli iptables-persistent deluged deluge-web deluge-console resolvconf- \


### PR DESCRIPTION
Merging in build 1.10.0

- Updating the libtorrent files from the default 1.2.9 to 1.2.12 by enabling the libtorrent channel. #20. 
- Also changed the main docker base back to Ubuntu to support more maintained packages and the main Ubuntu package size is a bit smaller.